### PR TITLE
ci: add semantic PR title check

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Set up Lua
+      uses: leafo/gh-actions-lua@v8
+
+    - name: Install dependencies and set up environment
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y luarocks
+
+        luarocks install busted --local
+        echo "$HOME/.luarocks/bin" >> $GITHUB_PATH
+
+    - name: Run tests
+      run: busted
+
+  semantic-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Check PR title for semantic prefix
+      uses: amannn/action-semantic-pull-request@v3

--- a/ci.yml
+++ b/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+permissions:
+  pull-requests: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -27,11 +30,7 @@ jobs:
       run: busted
 
   semantic-pr:
+    name: Validate PR title
     runs-on: ubuntu-latest
-
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Check PR title for semantic prefix
-      uses: amannn/action-semantic-pull-request@v3
+      - uses: amannn/action-semantic-pull-request@v5.4.0


### PR DESCRIPTION
Fixes #2

Add a GitHub action to check for semantic prefixes in PR titles.

* **ci.yml**
  - Add a new job `semantic-pr` to check for semantic prefix in PR titles.
  - Use the `amannn/action-semantic-pull-request@v3` GitHub action.
  - Configure the action to run on pull request events including opened, synchronize, reopened, and edited.
  - Add steps to the `test` job to set up Lua, install dependencies, and run tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/wow-sample-mod/issues/2?shareId=fddb7c62-afb6-4c6e-b62e-2ebc0e625030).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a GitHub action to enforce semantic prefixes in pull request titles and enhance the CI workflow with Lua setup and testing steps.

CI:
- Add a new GitHub action job `semantic-pr` to check for semantic prefixes in pull request titles using `amannn/action-semantic-pull-request@v3`.
- Configure the semantic PR title check to trigger on pull request events including opened, synchronize, reopened, and edited.
- Enhance the `test` job to include steps for setting up Lua, installing dependencies, and running tests.

<!-- Generated by sourcery-ai[bot]: end summary -->