### PR TITLE
ci: Use apt GitHub Action for installing dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,13 @@ jobs:
       uses: leafo/gh-actions-lua@v8
 
     - name: Install dependencies and set up environment
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y luarocks
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: luarocks
+        version: 1.0
 
-        luarocks install busted --local
-        echo "$HOME/.luarocks/bin" >> $GITHUB_PATH
+    - name: Install Lua dependencies
+      run: luarocks install busted --local
 
     - name: Run tests
       run: busted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
         version: 1.0
 
     - name: Install Lua dependencies
-      run: luarocks install busted --local
+      run: |
+        luarocks install busted --local
+        echo "$HOME/.luarocks/bin" >> $GITHUB_PATH
 
     - name: Run tests
       run: busted


### PR DESCRIPTION
Fixes #4

Replace `sudo apt-get` with GitHub's `apt` action in the CI workflow.

* Use `awalsh128/cache-apt-pkgs-action@latest` to install `luarocks`.
* Remove `sudo apt-get` commands from the workflow.
* Add a step to install Lua dependencies using `luarocks install busted --local`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/wow-sample-mod/issues/4?shareId=a44fcb56-c4cf-4206-8699-2e02301b9214).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the CI workflow to use GitHub's `apt` action for installing dependencies, replacing `sudo apt-get` commands, and add a step for installing Lua dependencies with `luarocks`.

CI:
- Replace `sudo apt-get` with `awalsh128/cache-apt-pkgs-action@latest` for installing `luarocks` in the CI workflow.
- Add a step to install Lua dependencies using `luarocks install busted --local` in the CI workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->