### PR TITLE
Add dungeon scoreboard

### DIFF
--- a/wow-sample-mod/wow-sample-mod.lua
+++ b/wow-sample-mod/wow-sample-mod.lua
@@ -65,3 +65,51 @@ if MySettingsFrame then
         MySettingsFrame.title:SetText("Settings")
     end
 end
+
+-- Create a table to store dungeon completion times and DPS
+local dungeonData = {}
+
+-- Function to update dungeon completion times and DPS
+local function UpdateDungeonData(dungeonName, completionTime, dps)
+    if not dungeonData[dungeonName] then
+        dungeonData[dungeonName] = { fastestTime = completionTime, highestDPS = dps }
+    else
+        if completionTime < dungeonData[dungeonName].fastestTime then
+            dungeonData[dungeonName].fastestTime = completionTime
+        end
+        if dps > dungeonData[dungeonName].highestDPS then
+            dungeonData[dungeonName].highestDPS = dps
+        end
+    end
+end
+
+-- Event handler for dungeon completion
+local function OnDungeonCompleted(event, dungeonName, completionTime, dps)
+    UpdateDungeonData(dungeonName, completionTime, dps)
+end
+
+-- Register event for dungeon completion
+local eventFrame = CreateFrame("Frame")
+eventFrame:RegisterEvent("DUNGEON_COMPLETED")
+eventFrame:SetScript("OnEvent", OnDungeonCompleted)
+
+-- Display the fastest dungeon completion times and highest DPS in the settings frame
+local function DisplayDungeonData()
+    if MySettingsFrame then
+        local content = ""
+        for dungeonName, data in pairs(dungeonData) do
+            content = content .. string.format("Dungeon: %s\nFastest Time: %s\nHighest DPS: %s\n\n", dungeonName, data.fastestTime, data.highestDPS)
+        end
+        if not MySettingsFrame.content then
+            MySettingsFrame.content = MySettingsFrame:CreateFontString(nil, "OVERLAY")
+            MySettingsFrame.content:SetFontObject("GameFontHighlight")
+            MySettingsFrame.content:SetPoint("TOPLEFT", MySettingsFrame, "TOPLEFT", 10, -30)
+        end
+        MySettingsFrame.content:SetText(content)
+    end
+end
+
+-- Update the settings frame to include the new information
+if MySettingsFrame then
+    MySettingsFrame:SetScript("OnShow", DisplayDungeonData)
+end


### PR DESCRIPTION
Fixes #12

Add functionality to track and display the fastest dungeon completion times and highest DPS.

* **wow-sample-mod/wow-sample-mod.lua**
  - Create a table to store dungeon completion times and DPS.
  - Add a function to update dungeon completion times and DPS.
  - Add an event handler for dungeon completion to update the table.
  - Register the event for dungeon completion.
  - Add a function to display the fastest dungeon completion times and highest DPS in the settings frame.
  - Update the settings frame to include the new information.

* **spec/test_wow_sample_mod_spec.lua**
  - Mock the necessary WoW API functions for dungeon completion times and DPS tracking.
  - Add tests for tracking dungeon completion times and DPS.
  - Verify that the fastest dungeon completion times and highest DPS are correctly tracked.
  - Verify that the fastest dungeon completion times and highest DPS are correctly displayed in the settings frame.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dciborow/wow-sample-mod/issues/12?shareId=ad96eb5d-f235-4c5f-bca3-6bfaf7ac4c49).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a dungeon scoreboard feature to track and display the fastest completion times and highest DPS for dungeons, and implement corresponding tests to ensure accurate tracking and display.

New Features:
- Introduce functionality to track and display the fastest dungeon completion times and highest DPS in the settings frame.

Tests:
- Add tests to verify the tracking of dungeon completion times and DPS, ensuring the fastest times and highest DPS are correctly recorded and displayed.

<!-- Generated by sourcery-ai[bot]: end summary -->